### PR TITLE
WPM-2929: use unique respondents while calculating overall

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SQLPivot/utils.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SQLPivot/utils.ts
@@ -72,7 +72,7 @@ function calculateRowAggregation(
 
   if (totalWeightedScoreIndex !== -1) {
     const totalResponsesIndex = data.cols.findIndex(
-      (col) => col.name === "total_responses",
+      (col) => col.name === "unique_respondents",
     );
 
     // Sum up total_weighted_score values


### PR DESCRIPTION
**Local**
<img width="1571" height="481" alt="image" src="https://github.com/user-attachments/assets/3deb8287-a2c2-4444-a3a9-cbfad80a80f1" />

**Metabase QA**
<img width="1631" height="586" alt="image" src="https://github.com/user-attachments/assets/7654e6be-e976-485b-ad68-7a80007ca279" />

