### PR TITLE
[MB][WPM-2920][Disable Unaggregated Field Chart Warnings]

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/RowChart/utils/warnings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/RowChart/utils/warnings.ts
@@ -1,23 +1,27 @@
 import type { CartesianChartColumns } from "metabase/visualizations/lib/graph/columns";
-import { unaggregatedDataWarning } from "metabase/visualizations/lib/warnings";
 import type { RowValues } from "metabase-types/api";
 
 export const getChartWarnings = (
-  chartColumns: CartesianChartColumns,
-  rows: RowValues[],
+  _chartColumns: CartesianChartColumns,
+  _rows: RowValues[],
 ) => {
-  const chartValuesKeys = new Set(
-    rows.map((row) => {
-      const dimensionValue = row[chartColumns.dimension.index];
-      return "breakout" in chartColumns
-        ? `${row[chartColumns.breakout.index]}:${dimensionValue}`
-        : String(dimensionValue);
-    }),
-  );
+  // Warning disabled per product team request #WPM-2920
+  // Original logic commented out for future reference:
+  //
+  // const chartValuesKeys = new Set(
+  //   rows.map((row) => {
+  //     const dimensionValue = row[chartColumns.dimension.index];
+  //     return "breakout" in chartColumns
+  //       ? `${row[chartColumns.breakout.index]}:${dimensionValue}`
+  //       : String(dimensionValue);
+  //   }),
+  // );
+  //
+  // const hasUngroupedData = chartValuesKeys.size < rows.length;
+  //
+  // return hasUngroupedData
+  //   ? [unaggregatedDataWarning(chartColumns.dimension.column, "y").text]
+  //   : [];
 
-  const hasUngroupedData = chartValuesKeys.size < rows.length;
-
-  return hasUngroupedData
-    ? [unaggregatedDataWarning(chartColumns.dimension.column, "y").text]
-    : [];
+  return [];
 };


### PR DESCRIPTION
https://github.com/user-attachments/assets/943dfcfc-b95a-4b67-b3d3-f34025c0fb2d

---

- Commented out the logic for generating warnings related to ungrouped data in the Row Chart visualization as per product team request.
- Retained original logic for future reference while ensuring the function returns an empty array to avoid warnings.
