### PR TITLE
[MB][WPM-2939][Add row aggregation sorting to SQL Pivot]

### DIFF
--- a/frontend/src/metabase/visualizations/visualizations/SQLPivot/settings.ts
+++ b/frontend/src/metabase/visualizations/visualizations/SQLPivot/settings.ts
@@ -138,6 +138,33 @@ export const SQL_PIVOT_SETTINGS = {
     getHidden: isColumnDimensionHidden,
   },
 
+  "sqlpivot.row_aggregation_sort": {
+    get section() {
+      return t`Display`;
+    },
+    get title() {
+      return t`Sort by row aggregation`;
+    },
+    get description() {
+      return t`Sort rows by their aggregated score`;
+    },
+    widget: "select",
+    default: "default",
+    getProps: () => ({
+      options: [
+        { name: t`Default order`, value: "default" },
+        { name: t`Ascending`, value: "asc" },
+        { name: t`Descending`, value: "desc" },
+      ],
+    }),
+    getHidden: (series: any, settings: any) => {
+      return (
+        isColumnDimensionHidden(series, settings) ||
+        !settings["sqlpivot.show_row_aggregation"]
+      );
+    },
+  },
+
   "sqlpivot.show_column_aggregation": {
     get section() {
       return t`Display`;


### PR DESCRIPTION
<details>
<summary><b>Test Report 1</b></summary>

https://github.com/user-attachments/assets/912d6604-4efe-4f9e-b0cf-138aa8d6e092
</details>

<details>
<summary><b>Test Report 2</b></summary>

https://github.com/user-attachments/assets/68c9bc1c-6e87-47b5-ba07-205915009e88
</details>

---

- Introduced a new setting for sorting rows by their aggregated score in the SQL Pivot visualization.
- Updated the SQLPivotSettings interface to include the new `row_aggregation_sort` option.
- Implemented helper functions for comparing numeric values and sorting rows based on the aggregation column.
- Enhanced the `transformToMatrixPivot` function to apply sorting when displaying rows with aggregation.
- Ensured that sorting respects user-defined settings for ascending, descending, or default order.